### PR TITLE
Support for POST requests + papercrowd.com parser

### DIFF
--- a/saexplorer.asd
+++ b/saexplorer.asd
@@ -115,6 +115,7 @@
                                    (:file "mathmeetings")
                                    (:file "chemistryconferences")
                                    (:file "paperleap")
+                                   (:file "papercrowd")
                                    (:file "wikicfp")))))
                (:file "keywords")
                (:file "conferences")

--- a/saexplorer.asd
+++ b/saexplorer.asd
@@ -114,6 +114,7 @@
                                    (:file "ams")
                                    (:file "mathmeetings")
                                    (:file "chemistryconferences")
+                                   (:file "paperleap")
                                    (:file "wikicfp")))))
                (:file "keywords")
                (:file "conferences")

--- a/src/cfp/spiders/papercrowd.lisp
+++ b/src/cfp/spiders/papercrowd.lisp
@@ -1,0 +1,50 @@
+;;;;
+;;;; https://www.papercrowd.com/medicine-and-health/pharmaceutical-conferences-2018
+;;;; TODO: generalize to load also other conferences on that website
+;;;;
+
+(in-package :cl-user)
+
+(defpackage :saexplorer.cfp.spider.papercrowd
+  (:use :cl)
+  (:import-from :saexplorer.cfp
+                #:make-cfp-reference-info
+                #:<cfp-spider> #:cfp-collect #:register-spider))
+
+(in-package :saexplorer.cfp.spider.papercrowd)
+
+(defclass <papercrowd> (<cfp-spider>)
+  ()
+  (:default-initargs :name "papercrowd"))
+
+(alexandria:define-constant +url+ "https://www.papercrowd.com/medicine-and-health/pharmaceutical/page" :test #'string=)
+
+(defun absolute-url (href)
+  (if (eql 0 (search "/" href))
+    (concatenate 'string "https://www.papercrowd.com" href)
+    href))
+
+(defmethod cfp-collect ((spider <papercrowd>))
+  (let* ((page-number 1))
+    (loop
+       :for page = (sa-utils:fetch-url +url+ :method :post :parameters `(("page" . ,(write-to-string page-number))))
+       :while page
+       :for doc-root = (plump:parse page)
+       :do (format t "processing page ~A" page-number)
+       :do (setf page-number (1+ page-number))
+       :append
+          (loop :for block :across (clss:select ".conference-summary-block" doc-root)
+             :for acronym-node = (aref (clss:select ".conference-short-name" block) 0)
+             :for name-node = (aref (clss:select ".conference-title" block) 0)
+             :for location-node = (aref (clss:select ".location" block) 0)
+             :for dates-node = (aref (clss:select ".conference-date:not(.location)" block) 0)
+             :collect
+               (make-cfp-reference-info
+                 :name (plump:text name-node)
+                 :acronym (plump:text acronym-node)
+                 :source-url (absolute-url (plump:attribute (plump:parent block) "href"))
+                 :dates (plump:text dates-node)
+                 :location (plump:text location-node))))))
+
+(eval-when (:load-toplevel)
+  (register-spider (make-instance '<papercrowd>)))

--- a/src/cfp/spiders/paperleap.lisp
+++ b/src/cfp/spiders/paperleap.lisp
@@ -1,0 +1,70 @@
+;;;; http://www.paperleap.com/cfp
+
+(in-package :cl-user)
+
+(defpackage :saexplorer.cfp.spider.paperleap
+  (:use :cl :saexplorer.cfp)
+  (:import-from :spider-utils
+                #:safe-first))
+
+(in-package :saexplorer.cfp.spider.paperleap)
+
+
+(defclass <paperleap> (saexplorer.cfp::<cfp-spider>)
+  ()
+  (:default-initargs :name "paperleap"))
+
+(defclass <depaginator> (spider-utils:<depaginator>)
+  ()
+  (:default-initargs
+   :initial-number 0))
+
+
+(defmethod spider-utils::initial-pages
+    ((depaginator <depaginator>))
+  ;; types=0 means Conference/workshop, types=1 means Journal/book
+  '("http://www.paperleap.com/cfp?types=0&page=~A"))
+
+(defmethod spider-utils::page-url
+    ((depaginator <depaginator>)
+     url-template
+     page-number)
+  (format nil url-template page-number))
+
+(defmethod spider-utils::process-single-page
+    ((depaginator <depaginator>)
+     page-number)
+  nil)
+
+(defmethod spider-utils::process-single-page
+    ((depaginator <depaginator>)
+     doc-root)
+  (loop
+     :for cfp-node :across (clss:select ".positions-list-item" doc-root)
+     :for acronym-node = (safe-first (clss:select "h2 > a" cfp-node))
+     :for name-node = (safe-first (clss:select "h2 > strong > a.f13" cfp-node))
+     :for dates-node = (safe-first (clss:select "h3" cfp-node))
+     :for city-node = (safe-first (clss:select "a[href*=\"?cities=\"]" dates-node))
+     :for country-node = (safe-first (clss:select "a[href*=\"?countries=\"]" dates-node))
+     :for deadline-node = (safe-first (clss:select "div > div.pull-right > span" cfp-node))
+     :collect
+     (saexplorer.cfp::make-cfp-reference-info
+       :name (plump:text name-node)
+       :acronym (plump:text acronym-node)
+       :source-url (plump:attribute name-node "href")
+       :dates (string-right-trim '(#\, #\Space) (plump:text (plump:first-child dates-node)))
+       :location (format nil "~A, ~A" (if city-node (plump:text city-node) "N/A") (if country-node (plump:text country-node) "N/A"))
+       :deadline (plump:text (plump:first-child deadline-node)))))
+
+(defmethod spider-utils::next-url ((depaginator <depaginator>) doc-root)
+  (safe-first (clss:select ".row > .col-sm-8 > a.btn.btn-default.pull-right" doc-root)))
+
+
+
+(defmethod saexplorer.cfp::cfp-collect ((spider <paperleap>))
+  (let ((depaginator (make-instance '<depaginator>)))
+    (spider-utils::process depaginator)))
+
+
+(eval-when (:load-toplevel)
+  (saexplorer.cfp::register-spider (make-instance '<paperleap>)))

--- a/src/utils/fetch.lisp
+++ b/src/utils/fetch.lisp
@@ -6,7 +6,7 @@
 (defconstant +default-proxy-port+ 3128)
 
 
-(defun fetch-url (url &key use-proxy)
+(defun fetch-url (url &key use-proxy (method :get) parameters)
   "Return content located at the specified URL."
   (log-message :trace "Downloading: ~A" url)
   (let ((proxy
@@ -20,7 +20,8 @@
                  (py-configparser:get-option *config* "Proxy" "password")))))
     (multiple-value-bind (content status-code server-headers)
         (drakma:http-request url
-                             :method :get
+                             :method method
+                             :parameters parameters
                              :proxy proxy
                              :proxy-basic-authorization proxy-auth
                              ;; :external-format-in :utf-8


### PR DESCRIPTION
* Added support for request type and parameters to `fetch-url` function.
* Added initial spider for https://www.papercrowd.com/. So far only https://www.papercrowd.com/medicine-and-health/pharmaceutical-conferences-2018. Should I generalize it to all conferences from that site?